### PR TITLE
production hardening pass

### DIFF
--- a/API/controllers/userController.js
+++ b/API/controllers/userController.js
@@ -1,74 +1,41 @@
 const userService = require("../services/firestore-functions");
 
-/*controller layer i want a function for register, read, update, and delete
+// user identity always comes from the verified Firebase token attached by
+// authMiddleware (req.user.uid). never trust id from query/body — that was
+// an IDOR vector where any logged-in caller could read or update any other
+// user's record. /register and /delete used to live here; registration is
+// handled by /auth/send-code?mode=create and account deletion is not a
+// user-facing feature today.
 
-Each function should have try catch, parse request, check format input, and validate token/UID*/
-
-
-
-//add user and return their id
-exports.registerUser = async (req, res) => {
-  try {
-    const data = req.body;
-
-    const result = await userService.registerUser(data);
-
-    res.status(201).json({
-      message: "User created successfully",
-      id: result.id
-    });
-  } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: error.message });
-  }
-};
-
-//update user and return status
-exports.updateUser = async (req, res) => {
-  try {
-    const data = req.body; 
-
-    const result = await userService.updateUser(data.id,data);
-
-    res.status(200).json({
-      message: "User updated successfully",
-      // user: result
-    });
-  } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: error.message });
-  }
-};
-
-//delete user with firebase id and return status
-exports.deleteUser = async (req, res) => {
-  try {
-    const data = req.body;
-
-    const result = await userService.deleteUser(data.id);
-
-    res.status(200).json({
-      message: "User deleted successfully",
-    });
-  } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: error.message });
-  }
-};
-
-//this is for login or anytime we want the users info
-//still need to add the google identity token check
-//request should contain user id for now but later google idendity should occur first before we get the id.
-//response is user info 
 exports.getUser = async (req, res) => {
   try {
-    const id = req.query.id || req.body?.id;
+    const id = req.user?.uid;
+    if (!id) return res.status(401).json({ error: "Unauthorized" });
 
     const result = await userService.readId(id);
 
     res.status(200).json({
       message: "User retrieved successfully",
       user: result ? result.data() : null,
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: error.message });
+  }
+};
+
+exports.updateUser = async (req, res) => {
+  try {
+    const id = req.user?.uid;
+    if (!id) return res.status(401).json({ error: "Unauthorized" });
+
+    // strip any client-supplied id so a caller can't rename the target doc
+    const { id: _ignored, ...patch } = req.body ?? {};
+
+    await userService.updateUser(id, patch);
+
+    res.status(200).json({
+      message: "User updated successfully",
     });
   } catch (error) {
     console.error(error);

--- a/API/middleware/requestLogger.js
+++ b/API/middleware/requestLogger.js
@@ -1,0 +1,24 @@
+// structured request log line emitted after every response. one JSON object
+// per request on stdout — Cloud Run forwards stdout to Cloud Logging, which
+// auto-parses JSON and maps `severity` to log levels.
+//
+// mounted above /auth so unauthenticated hits are logged too. req.user is set
+// by authMiddleware on protected routes; for /auth and /health it's undefined
+// and we record "anonymous".
+module.exports = function requestLogger(req, res, next) {
+  const start = Date.now();
+  res.on("finish", () => {
+    const status = res.statusCode;
+    const entry = {
+      severity: status >= 500 ? "ERROR" : status >= 400 ? "WARNING" : "INFO",
+      timestamp: new Date().toISOString(),
+      userId: req.user?.uid ?? "anonymous",
+      method: req.method,
+      path: (req.originalUrl || req.url).split("?")[0],
+      status,
+      durationMs: Date.now() - start,
+    };
+    console.log(JSON.stringify(entry));
+  });
+  next();
+};

--- a/API/routes/userRoutes.js
+++ b/API/routes/userRoutes.js
@@ -4,11 +4,7 @@ const router = express.Router();
 
 const userController = require("../controllers/userController");
 
-router.post("/register", userController.registerUser);
-
 router.get("/get", userController.getUser);
-
-router.post("/delete", userController.deleteUser);
 router.post("/update", userController.updateUser);
 
 module.exports = router;

--- a/API/server.js
+++ b/API/server.js
@@ -9,6 +9,7 @@ require('dotenv').config();
 const express=require('express');
 const cors=require('cors');
 const verification=require('./middleware/authMiddleware');
+const requestLogger=require('./middleware/requestLogger');
 
 
 const authRoutes = require('./routes/authRoutes');
@@ -24,6 +25,10 @@ const app=express();
 //json parser to convert text to objects
 app.use(cors());
 app.use(express.json());
+
+// mounted above the routes so every hit (auth + protected + /health) lands
+// in Cloud Logging with uid / method / path / status / duration
+app.use(requestLogger);
 
 app.get('/health',(req,res)=>{
     res.json({status:'OK',message:'AI PEER API is running'});

--- a/API/services/firestore-functions.js
+++ b/API/services/firestore-functions.js
@@ -12,22 +12,8 @@ module.exports = {
 
   //if changing more than one data field just overwrite with register
 
-  //new user account add duplicate check later
-  async registerUser(data){
-    //check for dup by calling seperate function checking if
-
-    try {
-      const res = await db.collection('users').add(data);
-
-      return res;
-    }
-    catch(error){
-      console.error("Firestore registerUser Error:", error);
-      throw error;
-    }
-  },
-
-  //update user info
+  // update user info. id always comes from the verified token in the
+  // controller — never from a client-supplied field.
   async updateUser(id,data){
 
     try {
@@ -40,19 +26,6 @@ module.exports = {
       throw error;
     }
 
-  },
-
-  async deleteUser(id){
-
-    try {
-    const res = await db.collection('users').doc(id).delete();
-
-    return res;
-    }
-    catch(error){
-    console.error("Firestore DeleteUser Error:", error);
-    throw error;
-    }
   },
 
   async readId(id){

--- a/PRODUCTION_MIGRATION.md
+++ b/PRODUCTION_MIGRATION.md
@@ -197,9 +197,8 @@ Collections the code writes to (from `API/services/firestore-functions.js` and `
 - `users/{uid}/activities/{YYYY-MM-DD}`: subcollection with `entries.<activityId>` map (daily-aggregated session records).
 - `verificationSessions/{phone}`: SMS cooldown and rate-limit state.
 - `refreshTokens/{uuid}`: 30-day session tokens issued after successful SMS verify.
-- `config/redcap`: single document holding REDCap API credentials (consumed by the scheduled function only).
 
-Firestore security rules for this project are currently permissive because every write path goes through the Express API under the Admin SDK. Before go-live, commit a `firestore.rules` file that denies all client-side access (all reads/writes from outside the Admin SDK must fail) and deploy with `firebase deploy --only firestore:rules --project prod`.
+Firestore and Cloud Storage security rules are now version-controlled in the repo (`firestore.rules` and `storage.rules`, wired into `firebase.json`). Both are deny-all: every write path goes through the Express API under the Admin SDK, which bypasses rules, so client-SDK traffic must fail. Deploy them with `firebase deploy --only firestore:rules,storage --project prod`.
 
 Enable daily Firestore backups via the console or `gcloud firestore backups schedules create`. Recommended retention: 30 days. If CoM requires point-in-time recovery, Firestore PITR is a separate opt-in and adds cost.
 
@@ -269,7 +268,15 @@ gcloud secrets add-iam-policy-binding identity-platform-api-key \
   --project=research-ai-peer-prod
 ```
 
-The dev project currently stores REDCap credentials inside the Firestore document `config/redcap`. Production should keep that pattern at launch to avoid code churn, but the REDCap token value written into that document should originate from Secret Manager so it can be rotated without touching Firestore.
+REDCap credentials are wired through `defineSecret()` in `functions/index.js`, which injects them into `process.env.REDCAP_API_URL` and `process.env.REDCAP_API_TOKEN` only while the scheduled run is executing. For production, name the secrets exactly `REDCAP_API_URL` and `REDCAP_API_TOKEN` (case-sensitive) so they match the `defineSecret()` calls without a code change:
+
+```bash
+# use firebase CLI so secretmanager.secretAccessor is granted automatically
+firebase functions:secrets:set REDCAP_API_URL --project research-ai-peer-prod
+firebase functions:secrets:set REDCAP_API_TOKEN --project research-ai-peer-prod
+```
+
+(If CoM prefers the `gcloud secrets create` / IAM-binding pattern used for the Identity Platform key above, the secret names in the table can stay kebab-case — but you must then rename the `defineSecret()` arguments in `functions/index.js` to match.)
 
 **Important key-rotation note:** the current dev Cloud Run config exposes the Identity Platform API key as a plaintext env var value. During migration, rotate this key in the Firebase console (regenerate a new one specifically for production) and store the rotated value in Secret Manager. Do not reuse the dev key in production.
 
@@ -303,7 +310,7 @@ The Cloud Run API service reads the following env vars (confirmed by `gcloud run
 | `NODE_ENV` | `development` | `production` | `--set-env-vars` on deploy |
 | `PORT` | unset (Cloud Run injects 8080) | unset | n/a |
 
-The Functions service reads REDCap credentials from Firestore, so no additional env vars are required beyond what Firebase Functions injects automatically.
+The Functions service reads REDCap credentials from Secret Manager via `defineSecret()` — no env vars to set on deploy. The Firebase Functions runtime injects the values into `process.env.REDCAP_API_URL` / `REDCAP_API_TOKEN` at invocation. Just run `firebase functions:secrets:set` once per secret (see section 7.3) before `firebase deploy --only functions:redcapSync`.
 
 ### 8.3 `.firebaserc` update
 
@@ -345,7 +352,12 @@ Notes:
 
 ## 10. Phase 6: Deploy the scheduled Functions
 
+Before the first deploy, populate the REDCap secrets (see section 7.3). `defineSecret()` in `functions/index.js` expects them to exist, and `firebase deploy` grants the runtime SA `secretmanager.secretAccessor` automatically:
+
 ```bash
+firebase functions:secrets:set REDCAP_API_URL --project prod
+firebase functions:secrets:set REDCAP_API_TOKEN --project prod
+
 cd functions
 firebase deploy --only functions --project prod
 ```
@@ -388,8 +400,10 @@ Run from a staff phone against a TestFlight / Internal Testing build before any 
 2. Take the FES-I questionnaire end-to-end. Confirm the activity record lands in `users/{uid}/activities/<today>/entries.fesi_*`.
 3. Run a Chair Rise test. Confirm the activity record lands with `category: "assessment"` and `exerciseId: "assessment-1"`.
 4. Trigger the AI Chat model download. Confirm the signed URL returns HTTP 200 and the GGUF downloads.
-5. Wait for 0200 ET or manually trigger `redcapsync`. Confirm the sync completes without error in Cloud Logging.
-6. Generate Cloud Logging alert policies for API 5xx rates and Functions failure rates, owned by the CoM IT on-call rotation.
+5. Wait for 0200 ET or manually trigger `redcapsync`. Confirm the sync completes without error in Cloud Logging and that no read against `config/redcap` shows up — credentials should come from Secret Manager only.
+6. Hit `/health` and one protected endpoint. Confirm Cloud Logging shows the structured JSON lines from the new request logger (`{timestamp, userId, method, path, status, durationMs}`), with `userId: "anonymous"` on `/health` and a Firebase uid on protected endpoints.
+7. Confirm Firestore and Storage rules report `PERMISSION_DENIED` to any non-Admin-SDK client via the Firebase console Rules Playground.
+8. Generate Cloud Logging alert policies for API 5xx rates and Functions failure rates, owned by the CoM IT on-call rotation.
 
 Patient rollout happens only after these six checks pass.
 
@@ -423,7 +437,7 @@ Once the production environment is live and has served successful smoke-test tra
 | SA | When it runs | Needs to read | Needs to write | Acts-as |
 |---|---|---|---|---|
 | `aipeer-api` | every API request | Firestore (all five collections), both GCS buckets, Identity Platform REST, Secret Manager for `identity-platform-api-key` | Firestore (users, verificationSessions, refreshTokens, activities subcollection), Firebase Auth (create custom tokens, verify ID tokens) | itself (for `signBlob`) |
-| `aipeer-redcap-sync` | 0200 ET daily | Firestore `config/redcap`, Firestore `users/*`, Secret Manager for `redcap-api-token` and `redcap-api-url` | Firestore `users/*` (score updates) | n/a |
+| `aipeer-redcap-sync` | 0200 ET daily | Firestore `users/*`, Secret Manager for `REDCAP_API_URL` and `REDCAP_API_TOKEN` (bound via `defineSecret()` in `functions/index.js`) | Firestore `users/*` (score updates) | n/a |
 | `aipeer-deployer` | on CI deploys only | Artifact Registry, Cloud Build | Cloud Run service definitions, Cloud Functions definitions, Artifact Registry images | `aipeer-api`, `aipeer-redcap-sync` |
 
 ## 17. Appendix B: open questions for CoM IT

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,11 @@
 {
+  "firestore": {
+    "rules": "firestore.rules",
+    "database": "ai-peer"
+  },
+  "storage": {
+    "rules": "storage.rules"
+  },
   "functions": [
     {
       "source": "functions",

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,13 @@
+rules_version = '2';
+
+// all mobile and admin access to user data goes through the Cloud Run API,
+// which authenticates with the Firebase Admin SDK (bypasses these rules).
+// no client should ever read or write Firestore directly — so deny all
+// client-SDK traffic at the rules layer.
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/front-end/AI-PEER/app/(tabs)/activity.tsx
+++ b/front-end/AI-PEER/app/(tabs)/activity.tsx
@@ -210,7 +210,7 @@ export default function ActivityScreen() {
     if (lastSyncedRate.current === complianceStats.rate) return;
     lastSyncedRate.current = complianceStats.rate;
 
-    api.updateUser(user.uid, {
+    api.updateUser({
       compliance_days_active: complianceStats.daysActive,
       compliance_rate: complianceStats.rate,
       compliance_updated_at: new Date().toISOString(),

--- a/front-end/AI-PEER/app/(tabs)/contacts.tsx
+++ b/front-end/AI-PEER/app/(tabs)/contacts.tsx
@@ -95,7 +95,7 @@ export default function ContactsScreen() {
 
     (async () => {
       try {
-        const res = await api.getUser(userId, authToken);
+        const res = await api.getUser(authToken);
         if (res.user?.contacts) {
           setContacts({
             emergency: res.user.contacts.emergency ?? [],
@@ -116,7 +116,7 @@ export default function ContactsScreen() {
       if (!userId || !authToken) return;
       setContacts(updated);
       try {
-        await api.updateUser(userId, { contacts: updated }, authToken);
+        await api.updateUser({ contacts: updated }, authToken);
       } catch (e) {
         console.log("[Contacts] Failed to save:", e);
       }

--- a/front-end/AI-PEER/app/(tabs)/index.tsx
+++ b/front-end/AI-PEER/app/(tabs)/index.tsx
@@ -47,7 +47,7 @@ export default function Home() {
         // Load btrack score from backend
         if (userId && authToken) {
           try {
-            const res = await api.getUser(userId, authToken);
+            const res = await api.getUser(authToken);
             if (isMounted && typeof res.user?.btrack_score === "number") {
               setBtrackScore(res.user.btrack_score);
             }
@@ -68,7 +68,7 @@ export default function Home() {
     setBtrackScore(newScore);
     if (userId && authToken) {
       try {
-        await api.updateUser(userId, { btrack_score: newScore }, authToken);
+        await api.updateUser({ btrack_score: newScore }, authToken);
       } catch (e) {
         console.log("[Home] Failed to save btrack:", e);
       }

--- a/front-end/AI-PEER/app/verify.tsx
+++ b/front-end/AI-PEER/app/verify.tsx
@@ -4,9 +4,9 @@ import { View, Text, TextInput, Keyboard, KeyboardAvoidingView, Platform, Toucha
 import { useRouter, useLocalSearchParams } from "expo-router";
 import { useTranslation } from "react-i18next";
 import { signInWithCustomToken } from "firebase/auth";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { auth } from "../src/firebaseClient";
 import { api } from "../src/api";
+import { setRefreshToken } from "../src/auth/tokenStore";
 import { usePrefs } from "../src/prefs-context";
 import { type ContrastPalette, scaleFontSizes, spacing, radii } from "../src/theme";
 
@@ -38,8 +38,9 @@ export default function Verify() {
 
       // Sign in with the custom token from the backend
       await signInWithCustomToken(auth, res.customToken);
-      // Store refresh token for persistent login (30-day session)
-      await AsyncStorage.setItem("refreshToken", res.refreshToken);
+      // Store refresh token for persistent login (30-day session). Lands in
+      // Keychain (iOS) / EncryptedSharedPreferences (Android), not AsyncStorage.
+      await setRefreshToken(res.refreshToken);
       console.log('[Auth] Refresh token stored after 2FA verification');
 
       // Navigate based on mode

--- a/front-end/AI-PEER/package-lock.json
+++ b/front-end/AI-PEER/package-lock.json
@@ -24,6 +24,7 @@
         "expo-linking": "~8.0.8",
         "expo-notifications": "~0.32.16",
         "expo-router": "~6.0.14",
+        "expo-secure-store": "~15.0.2",
         "expo-speech": "~14.0.8",
         "expo-splash-screen": "~31.0.10",
         "expo-status-bar": "~3.0.8",
@@ -101,6 +102,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1478,10 +1480,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2494,6 +2497,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.8.tgz",
       "integrity": "sha512-WiE9uCGRLUnShdjb9iP20sA3ToWrBbNXr14/N5mow7Nls9dmKgfGaGX5cynLvrltxq2OrDLh1VDNaUgsnS/k/g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -2560,6 +2564,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.8.tgz",
       "integrity": "sha512-4De6SUZ36zozl9kh5rZSxKWULpgty27rMzZ6x+xkoo7+NWyhWyFdsdvhFsWhTw/9GGj0wXIcbTjwHYCUIUuHyg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.8",
         "@firebase/component": "0.7.0",
@@ -2575,7 +2580,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.0",
@@ -3045,6 +3051,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3144,6 +3151,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
@@ -3680,6 +3693,7 @@
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
       "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "merge-options": "^3.0.4"
       },
@@ -3693,6 +3707,7 @@
       "integrity": "sha512-aLPUx43+WSeTOaUepR2FBD5a1V0OAZ1QB2DOlRlW4fOEjtBXgv40eM/ho8g3WCvAOKfPvTvx4fZdcuovTyV81Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-native-community/cli-clean": "20.1.1",
         "@react-native-community/cli-config": "20.1.1",
@@ -4625,6 +4640,7 @@
       "integrity": "sha512-s+7YFsH6e2xdvp+8vNu4lXKP3R0SA905/wbLnflDZhNon0EGxuYIj2225ehnY+sUgabBEM4cS088rFmTlHru8Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-native/js-polyfills": "0.84.0",
         "@react-native/metro-babel-transformer": "0.84.0",
@@ -4716,6 +4732,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.28.tgz",
       "integrity": "sha512-d1QDn+KNHfHGt3UIwOZvupvdsDdiHYZBEj7+wL2yDVo3tMezamYy60H9s3EnNVE1Ae1ty0trc7F2OKqo/RmsdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.14.0",
         "escape-string-regexp": "^4.0.0",
@@ -4983,6 +5000,7 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5062,6 +5080,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -5617,6 +5636,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5971,6 +5991,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -6001,7 +6034,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -6222,6 +6254,12 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6429,6 +6467,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6537,7 +6576,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -6556,7 +6594,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6570,7 +6607,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7264,7 +7300,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -7291,7 +7326,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -7438,7 +7472,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7646,7 +7679,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7656,7 +7688,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7694,7 +7725,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -7783,6 +7813,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7979,6 +8010,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8394,6 +8426,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.33.tgz",
       "integrity": "sha512-3yOEfAKqo+gqHcV8vKcnq0uA5zxlohnhA3fu4G43likN8ct5ZZ3LjAh9wDdKteEkoad3tFPvwxmXW711S5OHUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.23",
@@ -8441,6 +8474,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
+      "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "12.0.12",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
@@ -8478,6 +8520,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -8485,6 +8528,44 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-device": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-8.0.10.tgz",
+      "integrity": "sha512-jd5BxjaF7382JkDMaC+P04aXXknB2UhWaVx5WiQKA05ugm/8GH5uaz9P9ckWdMKZGQVVEOC8MHaUADoT26KmFA==",
+      "license": "MIT",
+      "dependencies": {
+        "ua-parser-js": "^0.7.33"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-device/node_modules/ua-parser-js": {
+      "version": "0.7.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
+      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/expo-file-system": {
@@ -8502,6 +8583,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -8552,6 +8634,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.11.tgz",
       "integrity": "sha512-+VSaNL5om3kOp/SSKO5qe6cFgfSIWnnQDSbA7XLs3ECkYzXRquk5unxNS3pg7eK5kNUmQ4kgLI7MhTggAEUBLA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.12",
         "invariant": "^2.2.4"
@@ -8586,6 +8669,26 @@
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.32.16",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.32.16.tgz",
+      "integrity": "sha512-QQD/UA6v7LgvwIJ+tS7tSvqJZkdp0nCSj9MxsDk/jU1GttYdK49/5L2LvE/4U0H7sNBz1NZAyhDZozg8xgBLXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~7.0.8",
+        "expo-constants": "~18.0.13"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -8864,6 +8967,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-15.0.8.tgz",
+      "integrity": "sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {
@@ -9420,7 +9532,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -9529,7 +9640,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9557,7 +9667,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -9600,7 +9709,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -9803,7 +9911,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9869,7 +9976,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -9898,7 +10004,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9911,7 +10016,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9967,6 +10071,15 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
@@ -10050,6 +10163,38 @@
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/i18next": {
+      "version": "25.10.10",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -10206,6 +10351,22 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -10310,7 +10471,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10423,7 +10583,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -10468,6 +10627,22 @@
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -10527,7 +10702,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10623,7 +10797,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -11682,7 +11855,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12455,11 +12627,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12469,7 +12656,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -12958,7 +13144,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13283,6 +13468,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13323,6 +13509,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -13348,6 +13535,33 @@
         "react": ">=17.0.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.6.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+      "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.10.9",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
@@ -13359,6 +13573,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -13438,6 +13653,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.6.tgz",
       "integrity": "sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -13466,6 +13682,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -13476,6 +13693,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -13530,6 +13748,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -13562,6 +13781,7 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -13586,6 +13806,7 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets-core/-/react-native-worklets-core-1.6.3.tgz",
       "integrity": "sha512-r3Q40XQBccx/iAI5tlyiua+micvO1UGzzUOskNweZUXyfrrE+rb5aqxqruBPqXf90rO+bBiplylLMEAXCLTyGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "string-hash-64": "^1.0.3"
       },
@@ -13698,6 +13919,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14180,7 +14402,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14344,7 +14565,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -15203,6 +15423,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15421,8 +15642,9 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15698,6 +15920,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -15937,6 +16172,15 @@
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
     },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -16108,7 +16352,6 @@
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",

--- a/front-end/AI-PEER/package.json
+++ b/front-end/AI-PEER/package.json
@@ -33,6 +33,7 @@
     "expo-linking": "~8.0.8",
     "expo-notifications": "~0.32.16",
     "expo-router": "~6.0.14",
+    "expo-secure-store": "~15.0.2",
     "expo-speech": "~14.0.8",
     "expo-splash-screen": "~31.0.10",
     "expo-status-bar": "~3.0.8",

--- a/front-end/AI-PEER/src/api.ts
+++ b/front-end/AI-PEER/src/api.ts
@@ -67,17 +67,19 @@ export const api = {
       { method: "POST", body: JSON.stringify({ refreshToken }) }
     ),
 
-  getUser: (id: string, token: string) =>
-    requestJSON<{ message: string; user: Record<string, any> }>(`/users/get?id=${id}`, {
+  // user identity comes from the bearer token on the server side, so no id
+  // is sent from the client. passing one would be ignored.
+  getUser: (token: string) =>
+    requestJSON<{ message: string; user: Record<string, any> }>("/users/get", {
       method: "GET",
       headers: { Authorization: `Bearer ${token}` },
     }),
 
-  updateUser: (id: string, data: Record<string, any>, token: string) =>
+  updateUser: (data: Record<string, any>, token: string) =>
     requestJSON<{ message: string }>("/users/update", {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
-      body: JSON.stringify({ id, ...data }),
+      body: JSON.stringify(data),
     }),
 
   getModelURL: (token: string) =>

--- a/front-end/AI-PEER/src/auth/AuthContext.tsx
+++ b/front-end/AI-PEER/src/auth/AuthContext.tsx
@@ -1,8 +1,8 @@
 import {createContext, useContext, useEffect, useState} from "react";
 import {User, signOut, signInWithCustomToken, onAuthStateChanged} from "firebase/auth";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import {auth} from '../firebaseClient';
 import {api} from '../api';
+import {getRefreshToken, clearRefreshToken} from './tokenStore';
 
 type AuthContextType = {
     user: User | null;
@@ -25,9 +25,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         let cancelled = false;
 
         const restoreSession = async () => {
-            console.log('[Auth] Checking AsyncStorage for refresh token...');
+            console.log('[Auth] Checking secure store for refresh token...');
             try {
-                const refreshToken = await AsyncStorage.getItem("refreshToken");
+                // reads from SecureStore, migrating any legacy AsyncStorage
+                // value on first run after the upgrade (see tokenStore.ts)
+                const refreshToken = await getRefreshToken();
 
                 if (!refreshToken) {
                     console.log('[Auth] No refresh token found, showing login screen');
@@ -50,7 +52,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             } catch (e: any) {
                 console.log('[Auth] Refresh failed:', e.message || e);
                 // Token expired or invalid — clear it
-                await AsyncStorage.removeItem("refreshToken");
+                await clearRefreshToken();
                 if (!cancelled) {
                     setUser(null);
                     setToken(null);
@@ -92,7 +94,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const logout = async (): Promise<void> => {
         console.log('[Auth] Logging out, clearing refresh token...');
-        await AsyncStorage.removeItem("refreshToken");
+        await clearRefreshToken();
         await signOut(auth);
     };
 

--- a/front-end/AI-PEER/src/auth/tokenStore.ts
+++ b/front-end/AI-PEER/src/auth/tokenStore.ts
@@ -1,0 +1,37 @@
+// Refresh token storage. The token is a 30-day bearer — leaking it is a
+// full account takeover, so it lives in expo-secure-store:
+//   - iOS: Keychain (hardware-backed on devices with Secure Enclave)
+//   - Android: EncryptedSharedPreferences backed by Android Keystore
+// Before this module existed the token sat in plaintext AsyncStorage. The
+// getRefreshToken() one-shot migration below keeps existing users signed
+// in across the upgrade: first run after update moves the legacy value into
+// SecureStore and wipes it from AsyncStorage.
+import * as SecureStore from "expo-secure-store";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const KEY = "refreshToken";
+
+export async function getRefreshToken(): Promise<string | null> {
+    const secure = await SecureStore.getItemAsync(KEY);
+    if (secure) return secure;
+
+    const legacy = await AsyncStorage.getItem(KEY);
+    if (legacy) {
+        await SecureStore.setItemAsync(KEY, legacy);
+        await AsyncStorage.removeItem(KEY);
+        return legacy;
+    }
+    return null;
+}
+
+export async function setRefreshToken(value: string): Promise<void> {
+    await SecureStore.setItemAsync(KEY, value);
+}
+
+export async function clearRefreshToken(): Promise<void> {
+    await SecureStore.deleteItemAsync(KEY);
+    // belt-and-suspenders during the rollout window: wipe the legacy
+    // AsyncStorage copy on every clear so nothing lingers even if the
+    // migration read path wasn't exercised for this user.
+    await AsyncStorage.removeItem(KEY);
+}

--- a/front-end/AI-PEER/src/llm/LLMContext.tsx
+++ b/front-end/AI-PEER/src/llm/LLMContext.tsx
@@ -10,6 +10,11 @@
  * - Model initialization state
  * - Generation state (for loading indicators)
  * - Multiple conversation management with 24-hour TTL
+ *
+ * PHI INVARIANT: conversations live in AsyncStorage on THIS device only.
+ * Do NOT upload to Firestore, GCS, the API, or any other backend.
+ * 24h max on-device retention — enforced at load, on every save, every 15
+ * minutes, and on app foreground. See filterExpiredConversations below.
  */
 
 import React, {
@@ -20,6 +25,7 @@ import React, {
   useCallback,
   ReactNode,
 } from 'react';
+import { AppState } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LLMState, ChatMessage, Conversation } from './types';
 import { STORAGE_KEYS, CONVERSATION_TTL_MS } from './config';
@@ -157,15 +163,39 @@ export function LLMProvider({ children }: { children: ReactNode }) {
     init();
   }, []);
 
-  // Save conversations whenever they change
+  // Save conversations whenever they change. filter expired entries before
+  // persisting so a conversation that aged past 24h in memory never gets
+  // re-written to disk — the load-time filter alone isn't enough once state
+  // has been hydrated.
   useEffect(() => {
     if (allConversations.length > 0) {
+      const toPersist = filterExpiredConversations(allConversations);
       AsyncStorage.setItem(
         STORAGE_KEYS.conversations,
-        JSON.stringify(allConversations)
+        JSON.stringify(toPersist)
       ).catch(console.error);
     }
   }, [allConversations]);
+
+  // Continuous sweep: every 15 minutes and whenever the app returns to the
+  // foreground, drop any conversation that has aged past the TTL. updating
+  // state triggers the save effect above, which rewrites AsyncStorage.
+  useEffect(() => {
+    const sweep = () => {
+      setAllConversations((prev) => {
+        const alive = filterExpiredConversations(prev);
+        return alive.length === prev.length ? prev : alive;
+      });
+    };
+    const interval = setInterval(sweep, 15 * 60 * 1000);
+    const sub = AppState.addEventListener('change', (s) => {
+      if (s === 'active') sweep();
+    });
+    return () => {
+      clearInterval(interval);
+      sub.remove();
+    };
+  }, []);
 
   // Save current conversation ID whenever it changes
   useEffect(() => {

--- a/functions/README.md
+++ b/functions/README.md
@@ -35,30 +35,33 @@ defined in `config/fieldMappings.js`.
 
 ## Config & secrets
 
-REDCap credentials are stored as fields inside a Firestore document, **not** in
-environment variables or Secret Manager.
+REDCap credentials live in **Google Cloud Secret Manager**, declared to the
+function via `defineSecret()` in `index.js`. The Functions runtime injects the
+values into `process.env` only while a scheduled run is executing.
 
-| Firestore path | Field | Description |
+| Secret name | Env var (at invocation) | Description |
 |---|---|---|
-| `config/redcap` (in the `ai-peer` database) | `apiToken` | REDCap API authentication token |
-| `config/redcap` | `apiUrl` | REDCap API endpoint URL |
+| `REDCAP_API_URL` | `process.env.REDCAP_API_URL` | REDCap API endpoint URL (must be HTTPS) |
+| `REDCAP_API_TOKEN` | `process.env.REDCAP_API_TOKEN` | REDCap API token for the service user |
 
-**To view the current token** (requires Firestore read access in the
-`research-ai-peer-dev` project):
+**To set or rotate a secret:**
 
 ```bash
-firebase firestore:get config/redcap --project research-ai-peer-dev
+firebase functions:secrets:set REDCAP_API_URL
+firebase functions:secrets:set REDCAP_API_TOKEN
 ```
 
-**To rotate the token**, update the document directly in the Firebase console
-or via the Admin SDK. The function caches the config in the `cachedConfig`
-module-level variable, so a rotation takes effect on the next cold start (next
-invocation after the current instance is recycled). If you need it to take
-effect immediately, redeploy the function to force a cold start:
+Each command prompts for the value. Rotation takes effect on the next deploy —
+`defineSecret()` pins the function to a specific secret version at deploy
+time, so redeploy after setting a new value:
 
 ```bash
 firebase deploy --only functions:redcapSync
 ```
+
+**Never commit credentials to Git or put them in `.env`**. `firebase deploy`
+grants the function's runtime service account `roles/secretmanager.secretAccessor`
+on each declared secret automatically.
 
 ---
 
@@ -123,19 +126,14 @@ firebase emulators:start --only functions
    emulator's HTTP trigger endpoint. From the Firebase emulator UI
    (`http://127.0.0.1:4000`), navigate to Functions and use the "Call" option.
 
-4. The function reads REDCap credentials from the `config/redcap` document in
-   the `ai-peer` Firestore database. When using the Firestore emulator, seed
-   that document before invoking:
+4. The function reads REDCap credentials from `process.env.REDCAP_API_URL` and
+   `process.env.REDCAP_API_TOKEN`, which are injected from Secret Manager at
+   invocation in production. For local emulator runs, export them yourself:
 
-```js
-// seed-config.js (run once against the emulator)
-const admin = require("firebase-admin");
-admin.initializeApp({ projectId: "research-ai-peer-dev" });
-const db = admin.firestore();
-db.collection("config").doc("redcap").set({
-  apiToken: "YOUR_TEST_TOKEN",
-  apiUrl: "https://your-redcap-instance/api/"
-});
+```bash
+export REDCAP_API_URL=https://your-redcap-instance/api/
+export REDCAP_API_TOKEN=YOUR_TEST_TOKEN
+firebase emulators:start --only functions
 ```
 
 5. Set `FIRESTORE_EMULATOR_HOST=127.0.0.1:8080` and
@@ -187,9 +185,10 @@ The deployed function handle is `redcapSync` (camelCase in code, normalized to
   document in `users` with no limit or cursor. This will time out or incur
   significant cost if the collection grows large.
 
-- **Config caching across retries**: `cachedConfig` is module-scoped. On a
-  warm retry within the same Cloud Run instance, a rotated API token will not
-  be picked up until a cold start.
+- **Secret rotation latency**: `defineSecret()` pins the function to a
+  specific secret version at deploy time. `firebase functions:secrets:set`
+  creates a new version but does NOT retarget running deployments — redeploy
+  (`firebase deploy --only functions:redcapSync`) to pick up the new value.
 
 - **No push notification on failure**: if all three retries are exhausted,
   there is no alerting beyond Cloud Logging. Consider adding a Cloud Monitoring

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,4 +1,5 @@
 const { onSchedule } = require("firebase-functions/v2/scheduler");
+const { defineSecret } = require("firebase-functions/params");
 const admin = require("firebase-admin");
 const { getFirestore } = require("firebase-admin/firestore");
 const { importToREDCap, exportFromREDCap } = require("./services/REDCap_Service");
@@ -11,13 +12,22 @@ if (!admin.apps.length) {
 
 const db = getFirestore("ai-peer");
 
+// REDCap credentials live in Secret Manager. set them once with:
+//   firebase functions:secrets:set REDCAP_API_URL
+//   firebase functions:secrets:set REDCAP_API_TOKEN
+// binding them here both scopes the secrets to this one function and
+// grants the runtime service account secretmanager.secretAccessor at deploy.
+const REDCAP_API_URL   = defineSecret("REDCAP_API_URL");
+const REDCAP_API_TOKEN = defineSecret("REDCAP_API_TOKEN");
+
 exports.redcapSync = onSchedule(
     {
         schedule: "0 2 * * *",       // 2am daily
         timeZone: "America/New_York",
         timeoutSeconds: 300,         // 5 min timeout for ~50 users
         retryCount: 3,                // retry up to 3 times on failure
-        serviceAccount: "munish@research-ai-peer-dev.iam.gserviceaccount.com"
+        serviceAccount: "munish@research-ai-peer-dev.iam.gserviceaccount.com",
+        secrets: [REDCAP_API_URL, REDCAP_API_TOKEN]
     },
     async (event) => {
         console.log("[SYNC] Starting REDCap sync...");

--- a/functions/services/REDCap_Service.js
+++ b/functions/services/REDCap_Service.js
@@ -1,41 +1,24 @@
 const fetch = require("node-fetch");
-const admin = require("firebase-admin");
-const { getFirestore } = require("firebase-admin/firestore");
 const { FIELD_MAPPINGS } = require("../config/fieldMappings");
 
-if (!admin.apps.length) {
-    admin.initializeApp();
-}
+// REDCap credentials come from Secret Manager via defineSecret() in index.js.
+// the Functions runtime injects them into process.env at invocation time —
+// they are not present when the module first loads, so read them lazily on
+// each call (not at top-level). previously these lived in Firestore at
+// config/redcap, which meant anyone with Firestore read access could grab
+// a token that has full project-level REDCap rights.
+async function loadREDCapConfig() {
+    const apiUrl = process.env.REDCAP_API_URL;
+    const apiToken = process.env.REDCAP_API_TOKEN;
 
-const db = getFirestore("ai-peer");
-
-let cachedConfig = null;
-
-async function loadREDCapConfig(){
-    if (cachedConfig)
-    {
-        return cachedConfig;
+    if (!apiUrl || !apiToken) {
+        throw new Error("REDCap secrets not injected — check defineSecret() binding on redcapSync");
+    }
+    if (!apiUrl.startsWith("https://")) {
+        throw new Error("REDCap apiUrl must be HTTPS");
     }
 
-    const docRef = db.doc("config/redcap");
-    const snap = await docRef.get();
-
-    if (!snap.exists)
-    {
-        throw new Error("REDCap config document not found in Firestore");
-    }
-
-    const {apiToken, apiUrl} = snap.data();
-    if (!apiUrl||!apiToken)
-    {
-        throw new Error("REDCap config is missing token or url");
-    }
-
-    cachedConfig={
-        apiUrl,
-        apiToken
-    };
-    return cachedConfig;
+    return { apiUrl, apiToken };
 }
 
 function buildREDCapRecord({userID, phonenum, btrack_score, fear_falling_score, compliance_days_active, compliance_rate})

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+
+// all GCS access runs through the Cloud Run API, which issues short-lived
+// v4 signed URLs via the IAM signBlob API. no client should ever hit
+// Firebase Storage directly, so deny all client-SDK traffic.
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
- redcap creds: firestore config/redcap -> secret manager via defineSecret()
- firestore.rules + storage.rules (deny-all; api uses admin sdk, clients never touch gcs/firestore directly)
- userController IDOR: identity from req.user.uid only, drop dead /users/register and /users/delete
- express request logger: json {timestamp, uid, method, path, status, durationMs} to stdout
- mobile refreshToken: asyncstorage -> expo-secure-store with one-shot migration
- llm chat: 24h ttl enforced on every save + 15min/appstate sweep, not just cold start; PHI invariant comment
- PRODUCTION_MIGRATION.md + functions/README.md refreshed for new patterns